### PR TITLE
Improved sync flow for removed appointments

### DIFF
--- a/src/modules/Controller/Sync.php
+++ b/src/modules/Controller/Sync.php
@@ -115,15 +115,15 @@ class Sync
             $this->retrieveAndStoreActivities();
 
             /**
-             * With the updated activity info we can remove obsolete appointments
-             */
-            $this->removeObsoleteActivitiesFromCalendar();
-
-            /**
              * Get all calendar appointments and store in the database
              * At this point the calendar no longer contains the activities that were just removed
              */
             $this->retrieveAndStoreAppointments();
+
+            /**
+             * With the updated activity info we can remove obsolete appointments
+             */
+            $this->removeObsoleteActivitiesFromCalendar();
 
             /**
              * Now that we have the actual activities and appointments we need to clean up the relation table
@@ -183,13 +183,13 @@ class Sync
      * Get all current appointments from the calendar
      * Update the appointments table to match the calendar
      */
-    private function retrieveAndStoreAppointments()
+    public function retrieveAndStoreAppointments()
     {
         $events = $this->cal->getEvents();
         if (!empty($events)) $this->activities->storeAppointments($events);
     }
 
-    private function removeObsoleteActivitiesFromCalendar()
+    public function removeObsoleteActivitiesFromCalendar()
     {
         $appointments = $this->activities->getObsoleteAppointments();
         if (!empty($appointments)) {

--- a/src/modules/Model/Calendar/Google.php
+++ b/src/modules/Model/Calendar/Google.php
@@ -133,26 +133,11 @@ class Google implements CalendarInterface
         //Remove the TMP id
         try {
             $this->cal->events->delete($this->agendaId, $appointmentId);
+            echo ('success!!1one');
         } catch (\Google\Service\Exception $e) {
-            $msg = $e->getMessage();
-            $obj = json_decode($msg);
-            //If the event is already removed from the calendar it is no problem, all other exceptions need to be addressed though
-            $ignore = false;
-            if ($msg != self::ERROR_RESOURCE_DELETED) {
-                if (isset($obj->error) && !empty($obj->error)) {
-                    if (isset($obj->error->message) && (!empty($obj->error->message))) {
-                        if ($obj->error->message != self::ERROR_RESOURCE_DELETED) {
-                            $ignore = true;
-                        }
-                    }
-                }
-            }
-
-            if (!$ignore) {
-                echo ('TODO: Store this output & implement proper error handling in code\n');
-                echo ('ErrorMessage: ' . $e->getMessage() . '\n');
-                echo ('Full error: ' . $e . '\n');
-            }
+            echo ('TODO: Store this output & implement proper error handling in code\n');
+            echo ('ErrorMessage: ' . $e->getMessage() . '\n');
+            echo ('Full error: ' . $e . '\n');
         }
     }
 

--- a/src/modules/Model/Database/Activities.php
+++ b/src/modules/Model/Database/Activities.php
@@ -165,7 +165,8 @@ class Activities extends Database
                 LEFT JOIN `activities` act on ata.act_inst_id = act.act_inst_id
                 LEFT JOIN `act_def` ad ON act.act_id = activity_id
                 LEFT JOIN `evt_def` ed on act.event_id = ed.event_id
-                WHERE act.user_id = (?) AND 
+                LEFT JOIN `appointments` apt ON ata.appointment_id = apt.appointment_id
+                WHERE act.user_id = (?) AND apt.appointment_id IS NOT NULL AND
                         (act.deleted = '1' OR ad.deleted = '1' OR ed.deleted = '1' OR ed.cancelled = '1')";
         parent::bufferParams($userid);
         parent::query($sql);


### PR DESCRIPTION
Appointments which were manually/previously removed but still had a mapping entry are no longer tried to be removed by the script